### PR TITLE
PORTAL-328 Add dependency to correctly handle CAS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
       <version>5.0-beta-1</version>
     </dependency>
     <dependency>
+      <groupId>org.esigate</groupId>
+      <artifactId>esigate-cas</artifactId>
+      <version>5.0-beta-1</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>


### PR DESCRIPTION
Added dependency to handle CAS, you can now add the class org.esigate.cas.CasAuthenticationHandler to the list of extensions for your provider the class will be called with no error
